### PR TITLE
Remove empty format precision specifier

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -169,7 +169,7 @@ impl App {
             if self.config.show_src {
                 write!(
                     tree_string,
-                    " {:.?}",
+                    " {:?}",
                     style(node.utf8_text(&self.src).unwrap()).cyan()
                 )
                 .unwrap();


### PR DESCRIPTION
A format precision specifier consisting of a dot and no number actually does nothing and has no specified meaning. Currently this is silently ignored, but it may turn into a warning or error.

See https://github.com/rust-lang/rust/issues/131159 and https://github.com/rust-lang/rust/pull/136638

Please leave a comment there if you have any opinion about this. If you remember why this was written this way that could help improve the diagnostics rustc gives.